### PR TITLE
一覧ページビューファイル編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: :new :create
+  before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    #@items = Item.all
+    @items = Item.all
   end
 
   def new

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -15,7 +15,7 @@ class Prefecture < ActiveHash::Base
     { id: 37, name: '香川県' }, { id: 38, name: '愛媛県' }, { id: 39, name: '高知県' },
     { id: 40, name: '福岡県' }, { id: 41, name: '佐賀県' }, { id: 42, name: '長崎県' },
     { id: 43, name: '熊本県' }, { id: 44, name: '大分県' }, { id: 45, name: '宮崎県' },
-    { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' },{ id: 48, name: '北海道' }
+    { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' }, { id: 48, name: '北海道' }
   ]
 
   include ActiveHash::Associations

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.item_price %>円<br><%= item.shipping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +153,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,8 +173,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'item_priceが9,999,999円以上だと登録できない' do
-        @item.item_price = 10000000
+        @item.item_price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Item price must be less than or equal to 9999999')
       end
@@ -100,13 +100,12 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include('Item price is not a number')
       end
-      
+
       it 'item_priceが半角英数だと登録できない' do
         @item.item_price = 'asdf'
         @item.valid?
         expect(@item.errors.full_messages).to include('Item price is not a number')
       end
-      
     end
   end
 end


### PR DESCRIPTION
# What
商品一覧表示機能の作成

# Why
商品一覧をトップページに表示させるため

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/8313166f1f7f300e0d89e13af2ba01b8

商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/10cf7f25812116e8f6209847b0105c2f
